### PR TITLE
Angular Material updated to 1.1.18

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
   ],
   "dependencies": {
     "angular": "^1.6.5",
-    "angular-material": "^1.1.4",
+    "angular-material": "^1.1.18",
     "moment": "^2.18.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-form-component",
-  "version": "1.0.55",
+  "version": "1.1.0",
   "description": "Angular Material based form component",
   "main": "dist/form-component.min.js",
   "scripts": {

--- a/src/tpl/form-component.tpl.html
+++ b/src/tpl/form-component.tpl.html
@@ -183,6 +183,8 @@
 	        md-item-text="item[config.autocompleteConfig.displayKey]"
 	        md-min-length="config.autocompleteConfig.minLength || 0"
 	        placeholder="{{config.placeholder}}"
+					md-menu-class="{{config.code}}-menu-class-autocomplete"
+					md-menu-container-class="{{config.code}}-menu-container-autocomplete"
 			data-auto="{{config.code}}-autocomplete">
 	      <md-item-template class="{{config.code}}-template-autocomplete" data-auto="{{config.code}}-template-autocomplete">
 	        <span ng-if="config.autocompleteConfig.displayKey" md-highlight-text="config.autocompleteConfig.searchText" md-highlight-flags="^i" title="{{item[config.autocompleteConfig.resultTitleKey] || item[config.autocompleteConfig.displayKey]}}" data-auto="{{config.code}}-{{item[config.autocompleteConfig.valueKey]}}-autocomplete">{{ item[config.autocompleteConfig.resultLabelKey] || item[config.autocompleteConfig.displayKey] }}</span>


### PR DESCRIPTION
1. Updated angular-material to 1.1.18
2. Added 'md-menu-class' and 'md-menu-container-class' to autocomplete